### PR TITLE
Fix tariff display bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ https://octopustracker.small3y.co.uk/?region=M&tariff=SILVER-24-04-03
 - **SILVER-24-10-01** – October 2024
 - **SILVER-24-12-31** – December 2024
 - **SILVER-25-04-11** – April 2025
+- **SILVER-25-04-15** – April 2025 V2
 
 ---
 

--- a/script.js
+++ b/script.js
@@ -176,6 +176,8 @@ function updateCurrentTariff() {
         tariffDisplayText = 'December 2024 v1';
     }else if (selectedTariff === 'SILVER-25-04-11') {
         tariffDisplayText = 'April 2025 v1';
+    } else if (selectedTariff === 'SILVER-25-04-15') {
+        tariffDisplayText = 'April 2025 v2';
     }
 
     document.getElementById('currentTariff').textContent = `Tariff: ${tariffDisplayText}`;


### PR DESCRIPTION
## Summary
- add April 2025 V2 tariff to README
- display correct text for the `SILVER-25-04-15` tariff in dashboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68444321f12c832a884f1fd241d3d0e9