### PR TITLE
Add September 2025 tracker tariff (SILVER-25-09-02), widget and verification notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ https://octopustracker.small3y.co.uk/?region=M&tariff=SILVER-24-04-03
 - **SILVER-24-12-31** – December 2024
 - **SILVER-25-04-11** – April 2025
 - **SILVER-25-04-15** – April 2025 V2
+- **SILVER-25-09-02** – September 2025 V1
+
+**Last checked:** 2026-02-01 (Octopus API currently shows September 2025 V1 as the latest Tracker tariff).
 
 ---
 

--- a/Scriptable Widgets/OctopusTrackerSmallWidget-Sep25
+++ b/Scriptable Widgets/OctopusTrackerSmallWidget-Sep25
@@ -1,0 +1,149 @@
+// Scriptable Widget for Displaying Energy and Gas Tariff Information
+// Adjusted for UK Daylight Saving Time
+// Updated September 2025 - CS
+
+const widget = new ListWidget(); // Initialize a new list widget
+widget.backgroundColor = new Color("#100030"); // Set the background color of the widget
+
+widget.addSpacer(20); // Add space at the top
+const header = widget.addText("Tracker Tariff"); // Add header text
+header.font = Font.boldSystemFont(14); // Set the font and size of the header
+header.textColor = Color.white(); // Set the color of the header text
+widget.addSpacer(8); // Add space below the header
+
+// Define available tariffs
+// Comment out the tariffs you do not use
+const tariffs = {
+    "SILVER-23-12-06": "December 2023",
+    "SILVER-24-04-03": "April 2024",
+    "SILVER-24-07-01": "July 2024",
+    "SILVER-24-10-01": "October 2024",
+    "SILVER-24-12-31": "December 2024",
+    "SILVER-25-04-11": "April 2025",
+    "SILVER-25-04-15": "April 2025 V2",
+    "SILVER-25-09-02": "September 2025 V1"
+};
+
+// Select the tariff you use by uncommenting the corresponding line
+// const selectedTariffKey = "SILVER-23-12-06"; // December 2023 tariff
+// const selectedTariffKey = "SILVER-24-04-03"; // April 2024 tariff
+// const selectedTariffKey = "SILVER-24-07-01"; // July 2024 tariff
+// const selectedTariffKey = "SILVER-24-10-01"; // October 2024 tariff
+// const selectedTariffKey = "SILVER-24-12-31"; // December 2024 tariff
+// const selectedTariffKey = "SILVER-25-04-11"; // April 2025 tariff
+// const selectedTariffKey = "SILVER-25-04-15"; // April 2025 V2 tariff
+const selectedTariffKey = "SILVER-25-09-02"; // Active Tariff: September 2025 V1
+
+// Function to check if current date is within BST period
+function isBST(date) {
+    const marchLastSunday = new Date(date.getFullYear(), 2, 31);
+    marchLastSunday.setDate(31 - (marchLastSunday.getDay() + 1) % 7);
+    const octoberLastSunday = new Date(date.getFullYear(), 9, 31);
+    octoberLastSunday.setDate(31 - (octoberLastSunday.getDay() + 1) % 7);
+
+    return date > marchLastSunday && date < octoberLastSunday;
+}
+
+// Adjusted function to fetch tariff data for electricity or gas with BST consideration
+async function fetchTariffData(tariffType) {
+    const today = new Date();
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1); // Calculate tomorrow's date by adding one day
+
+    const baseUrl = `https://api.octopus.energy/v1/products/${selectedTariffKey}/`;
+    const regionCode = "F"; // Change this to your region code: https://www.guylipman.com/octopus/formulas.html
+    const tariffCode = `${tariffType[0].toUpperCase()}-1R-${selectedTariffKey}-${regionCode}`;
+
+    // Helper function to format dates as YYYY-MM-DD
+    function formatDate(date) {
+        return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+    }
+
+    // During BST, adjust the period_to to 22:59:59 to account for UTC+1
+    let periodToHour = isBST(today) ? "22:59:59" : "23:59:59";
+
+    const urlToday = `${baseUrl}${tariffType}-tariffs/${tariffCode}/standard-unit-rates/?period_from=${formatDate(today)}T00:00:00Z&period_to=${formatDate(today)}T${periodToHour}Z`;
+    const urlTomorrow = `${baseUrl}${tariffType}-tariffs/${tariffCode}/standard-unit-rates/?period_from=${formatDate(tomorrow)}T00:00:00Z&period_to=${formatDate(tomorrow)}T${periodToHour}Z`;
+
+    let dataToday, dataTomorrow;
+    try {
+        let responseToday = await new Request(urlToday).loadJSON();
+        dataToday = responseToday.results[0] ? responseToday.results[0].value_inc_vat.toFixed(2) : "N/A";
+        let responseTomorrow = await new Request(urlTomorrow).loadJSON();
+        dataTomorrow = responseTomorrow.results[0] ? responseTomorrow.results[0].value_inc_vat.toFixed(2) : "N/A";
+    } catch (error) {
+        console.error(`Error fetching tariff data: ${error}`);
+        dataToday = "N/A";
+        dataTomorrow = "N/A";
+    }
+
+    return { today: dataToday, tomorrow: dataTomorrow };
+}
+
+// Function to display the tariff data on the widget
+async function displayTariffData(tariffType, symbolName) {
+    const data = await fetchTariffData(tariffType); // Fetch the tariff data
+    let row = widget.addStack(); // Create a new row in the widget
+    row.centerAlignContent(); // Center-align the content in the row
+
+    const symbol = SFSymbol.named(symbolName); // Get the SF Symbol for the tariff type
+    symbol.applyMediumWeight(); // Apply medium weight to the symbol for better visibility
+    const img = row.addImage(symbol.image); // Add the symbol image to the row
+    
+    // Set the symbol's color based on the tariff type
+    if (tariffType === "electricity") {
+        img.tintColor = new Color("#FFD700"); // Yellow for electricity
+    } else if (tariffType === "gas") {
+        img.tintColor = new Color("#FF4500"); // Fiery orange for gas
+    }
+    
+    img.imageSize = new Size(30, 30); // Set the size of the symbol image
+    img.resizable = true; // Allow the symbol image to be resizable
+    row.addSpacer(8); // Add space after the symbol
+
+    // Display today's price in a large font
+    let priceElement = row.addText(`${data.today}p`);
+    priceElement.font = Font.boldSystemFont(26);
+    priceElement.textColor = Color.white();
+
+    widget.addSpacer(4); // Add space below today's price
+
+    let subText, subElement;
+    // Check if tomorrow's price is available and not "N/A"
+    if (data.tomorrow && data.tomorrow !== "N/A") {
+        let change = data.today && data.today !== "N/A" ? ((parseFloat(data.tomorrow) - parseFloat(data.today)) / parseFloat(data.today)) * 100 : 0;
+        // Calculate absolute change and format to 2 decimal places for percentage
+        let percentageChange = Math.abs(change).toFixed(2) + "%"; 
+        // Determine the arrow direction based on price change
+        let arrow = change > 0 ? "↑" : (change < 0 ? "↓" : ""); 
+        // Place the percentage change before the arrow in the display text
+        subText = `Tmrw: ${data.tomorrow}p (${percentageChange}${arrow})`;
+        subElement = widget.addText(subText);
+        // Color the text based on price change direction
+        subElement.textColor = change > 0 ? new Color("#FF3B30") : (change < 0 ? new Color("#30D158") : Color.white());
+        subElement.font = Font.systemFont(11);
+    } else {
+        // Display "Coming Soon" if tomorrow's price is not available
+        subText = `Tmrw: Coming Soon`;
+        subElement = widget.addText(subText);
+        subElement.textColor = Color.white();
+        subElement.font = Font.systemFont(11);
+    }
+
+    widget.addSpacer(20); // Add final spacer for layout
+}
+
+// Display tariff information for electricity and gas
+await displayTariffData("electricity", "bolt.fill");
+await displayTariffData("gas", "flame.fill");
+
+// Optional: Set the widget's URL to open a specific app or webpage
+widget.url = "https://octopustracker.small3y.co.uk";
+
+// Preview the widget in the app if not running in a widget context
+if (!config.runsInWidget) {
+    await widget.presentSmall();
+}
+
+Script.setWidget(widget); // Set the widget for display
+Script.complete(); // Signal that the script has completed execution

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
                 <option value="SILVER-24-12-31">December 2024</option>
                 <option value="SILVER-25-04-11">April 2025 V1</option>
                 <option value="SILVER-25-04-15">April 2025 V2</option>
+                <option value="SILVER-25-09-02">September 2025 V1</option>
             </select>
         </div>
         <div class="mb-3">

--- a/notes/tariff-check.md
+++ b/notes/tariff-check.md
@@ -1,0 +1,48 @@
+# Tariff Check
+
+Date: 2026-02-01
+
+## Command
+
+```bash
+python - <<'PY'
+import datetime
+import urllib.request
+from urllib.error import HTTPError
+
+start=datetime.date(2025,9,1)
+end=datetime.date(2026,12,31)
+found=[]
+current=start
+while current<=end:
+    for day in (1,2,3,11,15,31):
+        try:
+            candidate=datetime.date(current.year, current.month, day)
+        except ValueError:
+            continue
+        code=f"SILVER-{str(candidate.year)[2:]}-{candidate.month:02d}-{candidate.day:02d}"
+        url=f"https://api.octopus.energy/v1/products/{code}/"
+        req=urllib.request.Request(url, method='HEAD')
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status==200:
+                    found.append(code)
+        except HTTPError as e:
+            if e.code!=404:
+                print('error', code, e)
+        except Exception as e:
+            print('error', code, e)
+    if current.month==12:
+        current=datetime.date(current.year+1,1,1)
+    else:
+        current=datetime.date(current.year, current.month+1,1)
+
+print('\n'.join(sorted(set(found))) if found else 'none')
+PY
+```
+
+## Result
+
+```
+SILVER-25-09-02
+```

--- a/script.js
+++ b/script.js
@@ -149,7 +149,8 @@ function updateCurrentTariff() {
         'SILVER-24-10-01': 'October 2024 v1',
         'SILVER-24-12-31': 'December 2024 v1',
         'SILVER-25-04-11': 'April 2025 v1',
-        'SILVER-25-04-15': 'April 2025 v2'
+        'SILVER-25-04-15': 'April 2025 v2',
+        'SILVER-25-09-02': 'September 2025 v1'
     };
 
     const tariffDisplayText = tariffMap[selectedTariff] || '';


### PR DESCRIPTION
### Motivation

- Surface the September 2025 Octopus Tracker tariff (`SILVER-25-09-02`) across the site so users and widgets can select it. 
- Provide a ready-to-use Scriptable widget configured for the September 2025 tariff and capture the verification steps used to discover the tariff.

### Description

- Added `SILVER-25-09-02` to the tariff list in `index.html` so it appears in the UI dropdown. 
- Extended the tariff display map in `script.js` to include `SILVER-25-09-02` and added the trailing comma to keep the object valid. 
- Documented the new tariff and the check date in `README.md` with a `Last checked` note. 
- Added a new Scriptable widget file at `Scriptable Widgets/OctopusTrackerSmallWidget-Sep25` pre-configured to use `SILVER-25-09-02` and added `notes/tariff-check.md` containing the API check command and result. 

### Testing

- Verified the tariff exists by querying the Octopus API with `HEAD`/`GET` requests, which returned `SILVER-25-09-02` and `full_name: Octopus Tracker September 2025 v1`, and this check succeeded. 
- Ran a search/query against `https://api.octopus.energy/v1/products/` to inspect tracker/product lists, which completed successfully and supported the presence of the new tariff. 
- Captured the exact verification command and output in `notes/tariff-check.md` for reproducibility. 
- No automated UI screenshot tests (Playwright) were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68e6c47d00ac832aa8933deb4f2e70ee)