### PR TITLE
Fix trend chart resizing loop and set April 2025 V2 as default tariff

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                 <option value="SILVER-24-10-01">October 2024</option>
                 <option value="SILVER-24-12-31">December 2024</option>
                 <option value="SILVER-25-04-11">April 2025 V1</option>
-                <option value="SILVER-25-04-15">April 2025 V2</option>
+                <option value="SILVER-25-04-15" selected>April 2025 V2</option>
                 <option value="SILVER-25-09-02">September 2025 V1</option>
             </select>
         </div>
@@ -77,7 +77,9 @@
         </div>
         <div id="priceTrendContainer" class="tile trend-tile">
             <div class="title h5">Electricity Price Trend (Past 7 Days)</div>
-            <canvas id="priceTrendChart" aria-label="7 day electricity price trend chart" role="img"></canvas>
+            <div class="trend-chart-wrapper">
+                <canvas id="priceTrendChart" aria-label="7 day electricity price trend chart" role="img"></canvas>
+            </div>
             <div id="chartStatus" class="chart-status">Loading trend...</div>
         </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -202,9 +202,15 @@ body {
     min-width: 400px;
 }
 
-#priceTrendChart {
+.trend-chart-wrapper {
+    position: relative;
     width: 100%;
-    min-height: 280px;
+    height: 280px;
+}
+
+#priceTrendChart {
+    width: 100% !important;
+    height: 100% !important;
 }
 
 .chart-status {


### PR DESCRIPTION
### Motivation
- The 7-day trend chart was subject to a responsive resize/feedback loop that caused the chart area to grow while scrolling, so the canvas needs a constrained container to prevent uncontrolled expansion.
- The default tariff should be set to the most recent tariff minus one for the expected default selection behavior.

### Description
- Set the default tariff option to `SILVER-25-04-15` by adding the `selected` attribute in `index.html` so the dropdown defaults to April 2025 V2.
- Wrapped the trend chart canvas in a fixed-height container `<div class="trend-chart-wrapper">` in `index.html` to constrain layout and stop repeated resize growth.
- Added `.trend-chart-wrapper` rules and changed `#priceTrendChart` to `width: 100% !important; height: 100% !important;` in `styles.css` so the canvas fills the wrapper instead of using `min-height`.
- Modified `index.html` and `styles.css` only (`script.js` unchanged) to implement the layout fix and default selection.

### Testing
- Served the site locally with `python3 -m http.server 4173` and verified the page loaded successfully (server run completed).
- Captured a browser screenshot using Playwright to validate the updated layout and chart container (`artifacts/trend-chart-fix.png`) and the run completed successfully.
- Confirmed changes were committed to the branch via `git show --stat --oneline` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b075ac29f8832a9019940f8ca83b51)